### PR TITLE
tagged nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "art"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "adaptive radix trie"

--- a/src/bin/art_bench.rs
+++ b/src/bin/art_bench.rs
@@ -74,8 +74,7 @@ impl std::hash::Hasher for Hasher {
 }
 
 #[allow(unused)]
-type FastMap8<K, V> =
-    std::collections::HashMap<K, V, std::hash::BuildHasherDefault<Hasher>>;
+type FastMap8<K, V> = std::collections::HashMap<K, V, std::hash::BuildHasherDefault<Hasher>>;
 
 fn main() {
     const N: u64 = 10_000_000;
@@ -96,7 +95,9 @@ fn main() {
             println!(
                 "{:.2} million wps {} mb allocated {} mb freed {} mb resident",
                 k as f64 / (before_writes.elapsed().as_micros().max(1)) as f64,
-                allocated(), freed(), resident(),
+                allocated(),
+                freed(),
+                resident(),
             )
         }
     }
@@ -109,7 +110,9 @@ fn main() {
             println!(
                 "{:.2} million rps {} mb allocated {} mb freed {} mb resident",
                 k as f64 / (before_reads.elapsed().as_micros().max(1)) as f64,
-                allocated(), freed(), resident(),
+                allocated(),
+                freed(),
+                resident(),
             )
         }
     }
@@ -122,7 +125,11 @@ fn main() {
     freed();
     let before_free = std::time::Instant::now();
     drop(art);
-    println!("freeing Art cleared {} mb in {:?}", freed(), before_free.elapsed());
+    println!(
+        "freeing Art cleared {} mb in {:?}",
+        freed(),
+        before_free.elapsed()
+    );
 
     println!();
     println!("BTreeMap:");
@@ -136,7 +143,9 @@ fn main() {
             println!(
                 "{:.2} million wps {} mb allocated {} mb freed {} mb resident",
                 k as f64 / (before_writes.elapsed().as_micros().max(1)) as f64,
-                allocated(), freed(), resident(),
+                allocated(),
+                freed(),
+                resident(),
             )
         }
     }
@@ -149,7 +158,9 @@ fn main() {
             println!(
                 "{:.2} million rps {} mb allocated {} mb freed {} mb resident",
                 k as f64 / (before_reads.elapsed().as_micros().max(1)) as f64,
-                allocated(), freed(), resident(),
+                allocated(),
+                freed(),
+                resident(),
             )
         }
     }
@@ -162,7 +173,11 @@ fn main() {
     freed();
     let before_free = std::time::Instant::now();
     drop(btree);
-    println!("freeing BTreeMap cleared {} mb in {:?}", freed(), before_free.elapsed());
+    println!(
+        "freeing BTreeMap cleared {} mb in {:?}",
+        freed(),
+        before_free.elapsed()
+    );
 
     println!();
     println!("HashMap:");
@@ -176,7 +191,9 @@ fn main() {
             println!(
                 "{:.2} million wps {} mb allocated {} mb freed {} mb resident",
                 k as f64 / (before_writes.elapsed().as_micros().max(1)) as f64,
-                allocated(), freed(), resident(),
+                allocated(),
+                freed(),
+                resident(),
             )
         }
     }
@@ -189,7 +206,9 @@ fn main() {
             println!(
                 "{:.2} million rps {} mb allocated {} mb freed {} mb resident",
                 k as f64 / (before_reads.elapsed().as_micros().max(1)) as f64,
-                allocated(), freed(), resident(),
+                allocated(),
+                freed(),
+                resident(),
             )
         }
     }
@@ -202,5 +221,9 @@ fn main() {
     freed();
     let before_free = std::time::Instant::now();
     drop(hash);
-    println!("freeing HashMap cleared {} mb in {:?}", freed(), before_free.elapsed());
+    println!(
+        "freeing HashMap cleared {} mb in {:?}",
+        freed(),
+        before_free.elapsed()
+    );
 }

--- a/src/bin/art_bench.rs
+++ b/src/bin/art_bench.rs
@@ -89,7 +89,7 @@ fn main() {
     let before_writes = std::time::Instant::now();
     for k in 0_u64..N {
         //println!("{}", k);
-        assert!(art.insert(k.to_le_bytes(), VALUE).is_none());
+        assert!(art.insert(k.to_be_bytes(), VALUE).is_none());
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million wps {} mb allocated {} mb freed {} mb resident",
@@ -102,7 +102,7 @@ fn main() {
 
     let before_reads = std::time::Instant::now();
     for k in 0_u64..N {
-        assert_eq!(art.get(&k.to_le_bytes()), Some(&VALUE));
+        assert_eq!(art.get(&k.to_be_bytes()), Some(&VALUE));
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million rps {} mb allocated {} mb freed {} mb resident",
@@ -129,7 +129,7 @@ fn main() {
     let before_writes = std::time::Instant::now();
     for k in 0_u64..N {
         //println!("{}", k);
-        assert!(btree.insert(k.to_le_bytes(), VALUE).is_none());
+        assert!(btree.insert(k.to_be_bytes(), VALUE).is_none());
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million wps {} mb allocated {} mb freed {} mb resident",
@@ -142,7 +142,7 @@ fn main() {
 
     let before_reads = std::time::Instant::now();
     for k in 0_u64..N {
-        assert_eq!(btree.get(&k.to_le_bytes()), Some(&VALUE));
+        assert_eq!(btree.get(&k.to_be_bytes()), Some(&VALUE));
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million rps {} mb allocated {} mb freed {} mb resident",
@@ -169,7 +169,7 @@ fn main() {
     let before_writes = std::time::Instant::now();
     for k in 0_u64..N {
         //println!("{}", k);
-        assert!(hash.insert(k.to_le_bytes(), VALUE).is_none());
+        assert!(hash.insert(k.to_be_bytes(), VALUE).is_none());
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million wps {} mb allocated {} mb freed {} mb resident",
@@ -182,7 +182,7 @@ fn main() {
 
     let before_reads = std::time::Instant::now();
     for k in 0_u64..N {
-        assert_eq!(hash.get(&k.to_le_bytes()), Some(&VALUE));
+        assert_eq!(hash.get(&k.to_be_bytes()), Some(&VALUE));
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million rps {} mb allocated {} mb freed {} mb resident",

--- a/src/bin/art_bench.rs
+++ b/src/bin/art_bench.rs
@@ -80,7 +80,9 @@ type FastMap8<K, V> =
 fn main() {
     const N: u64 = 10_000_000;
 
-    const VALUE: () = ();
+    const VALUE: u8 = 0;
+
+    let convert = u64::to_be_bytes;
 
     println!();
     println!("Art:");
@@ -89,7 +91,7 @@ fn main() {
     let before_writes = std::time::Instant::now();
     for k in 0_u64..N {
         //println!("{}", k);
-        assert!(art.insert(k.to_be_bytes(), VALUE).is_none());
+        assert!(art.insert(convert(k), VALUE).is_none());
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million wps {} mb allocated {} mb freed {} mb resident",
@@ -102,7 +104,7 @@ fn main() {
 
     let before_reads = std::time::Instant::now();
     for k in 0_u64..N {
-        assert_eq!(art.get(&k.to_be_bytes()), Some(&VALUE));
+        assert_eq!(art.get(&convert(k)), Some(&VALUE));
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million rps {} mb allocated {} mb freed {} mb resident",
@@ -129,7 +131,7 @@ fn main() {
     let before_writes = std::time::Instant::now();
     for k in 0_u64..N {
         //println!("{}", k);
-        assert!(btree.insert(k.to_be_bytes(), VALUE).is_none());
+        assert!(btree.insert(convert(k), VALUE).is_none());
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million wps {} mb allocated {} mb freed {} mb resident",
@@ -142,7 +144,7 @@ fn main() {
 
     let before_reads = std::time::Instant::now();
     for k in 0_u64..N {
-        assert_eq!(btree.get(&k.to_be_bytes()), Some(&VALUE));
+        assert_eq!(btree.get(&convert(k)), Some(&VALUE));
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million rps {} mb allocated {} mb freed {} mb resident",
@@ -169,7 +171,7 @@ fn main() {
     let before_writes = std::time::Instant::now();
     for k in 0_u64..N {
         //println!("{}", k);
-        assert!(hash.insert(k.to_be_bytes(), VALUE).is_none());
+        assert!(hash.insert(convert(k), VALUE).is_none());
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million wps {} mb allocated {} mb freed {} mb resident",
@@ -182,7 +184,7 @@ fn main() {
 
     let before_reads = std::time::Instant::now();
     for k in 0_u64..N {
-        assert_eq!(hash.get(&k.to_be_bytes()), Some(&VALUE));
+        assert_eq!(hash.get(&convert(k)), Some(&VALUE));
         if (k + 1) % (N / 10) == 0 {
             println!(
                 "{:.2} million rps {} mb allocated {} mb freed {} mb resident",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ fn map_bound<T, U, F: FnOnce(T) -> U>(bound: Bound<T>, f: F) -> Bound<U> {
 }
 
 #[cfg(target_pointer_width = "64")]
-const fn size_tests() {
+const fn _size_tests() {
     use std::mem::size_of;
     let _: [u8; 8] = [0; size_of::<Node<()>>()];
     let _: [u8; 16] = [0; size_of::<Header>()];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,20 @@ pub struct Art<ValueType, const KEY_LENGTH: usize> {
     root: Node<ValueType>,
 }
 
-impl <V: fmt::Debug, const K: usize> fmt::Debug for Art<V, K> {
+impl<V, const K: usize> FromIterator<([u8; K], V)> for Art<V, K> {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = ([u8; K], V)>
+    {
+        let mut art = Art::new();
+        for (k, v) in iter {
+            art.insert(k, v);
+        }
+        art
+    }
+}
+
+impl<V: fmt::Debug, const K: usize> fmt::Debug for Art<V, K> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Art ")?;
         f.debug_map()
@@ -106,7 +119,8 @@ impl<V, const K: usize> Art<V, K> {
                     *children = children.checked_sub(1).unwrap();
 
                     if *children == 48 || *children == 16
-                        || *children == 4 || *children == 0 {
+                        || *children == 4 || *children == 1
+                        || *children == 0 {
                         self.prune(key);
                     }
                 }
@@ -1749,4 +1763,19 @@ fn regression_06() {
     }
 
     assert!(art.root.is_none());
+}
+
+#[test]
+fn regression_07() {
+    fn run<T: Default>() {
+        let _ = [([], Default::default())].into_iter().collect::<Art<(), 0>>();
+    }
+    run::<()>();
+    run::<u8>();
+    run::<u16>();
+    run::<u32>();
+    run::<u64>();
+    run::<usize>();
+    run::<String>();
+    run::<Vec<usize>>();
 }


### PR DESCRIPTION
This further reduces memory usage by a further 44% for sparse workloads on top of the changes in https://github.com/komora-io/art/pull/1:
```
Art:
6.77 million wps 46 mb allocated 3 mb freed 43 mb resident
6.07 million wps 74 mb allocated 10 mb freed 107 mb resident
6.00 million wps 32 mb allocated 0 mb freed 139 mb resident
5.09 million wps 167 mb allocated 42 mb freed 263 mb resident
4.80 million wps 32 mb allocated 0 mb freed 295 mb resident
4.58 million wps 32 mb allocated 0 mb freed 327 mb resident
4.44 million wps 32 mb allocated 0 mb freed 359 mb resident
4.37 million wps 32 mb allocated 0 mb freed 391 mb resident
4.33 million wps 32 mb allocated 0 mb freed 423 mb resident
4.29 million wps 32 mb allocated 0 mb freed 455 mb resident
[src/bin/art_bench.rs:104] before_writes.elapsed() = 2.328520354s
8.63 million rps 0 mb allocated 0 mb freed 455 mb resident
7.57 million rps 0 mb allocated 0 mb freed 455 mb resident
7.33 million rps 0 mb allocated 0 mb freed 455 mb resident
7.12 million rps 0 mb allocated 0 mb freed 455 mb resident
6.91 million rps 0 mb allocated 0 mb freed 455 mb resident
6.86 million rps 0 mb allocated 0 mb freed 455 mb resident
6.87 million rps 0 mb allocated 0 mb freed 455 mb resident
6.87 million rps 0 mb allocated 0 mb freed 455 mb resident
6.92 million rps 0 mb allocated 0 mb freed 455 mb resident
6.92 million rps 0 mb allocated 0 mb freed 455 mb resident
[src/bin/art_bench.rs:119] before_reads.elapsed() = 1.444598616s
full scan took 2.112699866s
freeing Art cleared 455 mb in 2.561720767s
```
(performed on different machine so the timing differences are not interesting here, just the memory consumption which is identical)