### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/bin/art_bench.rs
+++ b/src/bin/art_bench.rs
@@ -167,7 +167,7 @@ fn main() {
     dbg!(before_reads.elapsed());
 
     let before_scan = std::time::Instant::now();
-    assert_eq!(btree.iter().count() as u64, N);
+    assert_eq!(btree.len() as u64, N);
     println!("full scan took {:?}", before_scan.elapsed());
 
     freed();
@@ -215,7 +215,7 @@ fn main() {
     dbg!(before_reads.elapsed());
 
     let before_scan = std::time::Instant::now();
-    assert_eq!(hash.iter().count() as u64, N);
+    assert_eq!(hash.len() as u64, N);
     println!("full scan took {:?}", before_scan.elapsed());
 
     freed();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,7 @@ impl<V: PartialEq, const K: usize> PartialEq for Art<V, K> {
             }
         }
 
-        if other_iter.next().is_none() {
-            true
-        } else {
-            false
-        }
+        other_iter.next().is_none()
     }
 }
 
@@ -221,7 +217,7 @@ impl<V, const K: usize> Art<V, K> {
     }
 
     pub fn get(&self, key: &[u8; K]) -> Option<&V> {
-        let mut k: &[u8] = &*key;
+        let mut k: &[u8] = key;
         let mut cursor: &Node<V> = &self.root;
 
         while !k.is_empty() {
@@ -236,8 +232,8 @@ impl<V, const K: usize> Art<V, K> {
         }
 
         match cursor.deref() {
-            NodeRef::Value(ref v) => return Some(v),
-            NodeRef::None => return None,
+            NodeRef::Value(v) => Some(v),
+            NodeRef::None => None,
             _ => unreachable!(),
         }
     }
@@ -246,7 +242,7 @@ impl<V, const K: usize> Art<V, K> {
         self.range(..)
     }
 
-    pub fn range<'a, R>(&'a self, range: R) -> Iter<'a, V, K>
+    pub fn range<R>(&self, range: R) -> Iter<'_, V, K>
     where
         R: RangeBounds<[u8; K]>,
     {
@@ -417,7 +413,7 @@ impl<'a, V, const K: usize> Iterator for Iter<'a, V, K> {
             let can_return = in_bounds && !finished;
             self.finished_0 = true;
             match self.root.node.deref() {
-                NodeRef::Value(ref v) if can_return => return Some(([0; K], v)),
+                NodeRef::Value(v) if can_return => return Some(([0; K], v)),
                 NodeRef::Value(_) | NodeRef::None => return None,
                 _ => unreachable!(),
             }
@@ -497,7 +493,7 @@ impl<'a, V, const K: usize> DoubleEndedIterator for Iter<'a, V, K> {
             let can_return = in_bounds && !finished;
             self.finished_0 = true;
             match self.root.node.deref() {
-                NodeRef::Value(ref v) if can_return => return Some(([0; K], v)),
+                NodeRef::Value(v) if can_return => return Some(([0; K], v)),
                 NodeRef::Value(_) | NodeRef::None => return None,
                 _ => unreachable!(),
             }
@@ -1110,7 +1106,7 @@ impl<V> Default for Node1<V> {
 }
 
 impl<V> Node1<V> {
-    fn iter<'a>(&'a self) -> impl DoubleEndedIterator<Item = (u8, &Node<V>)> {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = (u8, &Node<V>)> {
         std::iter::once((self.key, &self.slot))
     }
 
@@ -1154,7 +1150,7 @@ impl<V> Default for Node4<V> {
 }
 
 impl<V> Node4<V> {
-    fn iter<'a>(&'a self) -> impl DoubleEndedIterator<Item = (u8, &Node<V>)> {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = (u8, &Node<V>)> {
         let mut pairs: [(u8, &Node<V>); 4] = [
             (self.keys[0], &self.slots[0]),
             (self.keys[1], &self.slots[1]),
@@ -1259,7 +1255,7 @@ impl<V> Default for Node16<V> {
 }
 
 impl<V> Node16<V> {
-    fn iter<'a>(&'a self) -> impl DoubleEndedIterator<Item = (u8, &Node<V>)> {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = (u8, &Node<V>)> {
         let mut pairs: [(u8, &Node<V>); 16] = [
             (self.keys[0], &self.slots[0]),
             (self.keys[1], &self.slots[1]),
@@ -1411,7 +1407,7 @@ impl<V> Default for Node48<V> {
 }
 
 impl<V> Node48<V> {
-    fn iter<'a>(&'a self) -> impl DoubleEndedIterator<Item = (u8, &Node<V>)> {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = (u8, &Node<V>)> {
         self.child_index
             .iter()
             .enumerate()
@@ -1488,7 +1484,7 @@ struct Node256<V> {
 }
 
 impl<V> Node256<V> {
-    fn iter<'a>(&'a self) -> impl DoubleEndedIterator<Item = (u8, &Node<V>)> {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = (u8, &Node<V>)> {
         self.slots
             .iter()
             .enumerate()
@@ -1899,16 +1895,16 @@ fn regression_03() {
 
         let mut b = k[1];
         // byte at index 0 is k[0]
-        for i in 1..5 {
+        for byte in ret.iter_mut().take(5).skip(1) {
             if b.leading_zeros() == 0 {
-                ret[i] = 255;
+                *byte = 255;
             }
             b = b.rotate_left(1);
         }
         // byte at index 5 is k[2]
-        for i in 6..10 {
+        for byte in ret.iter_mut().take(10).skip(6) {
             if b.leading_zeros() == 0 {
-                ret[i] = 255;
+                *byte = 255;
             }
             b = b.rotate_left(1);
         }
@@ -1975,9 +1971,7 @@ fn regression_06() {
 #[test]
 fn regression_07() {
     fn run<T: Default>() {
-        let _ = [([], Default::default())]
-            .into_iter()
-            .collect::<Art<(), 0>>();
+        let _ = [([], T::default())].into_iter().collect::<Art<T, 0>>();
     }
     run::<()>();
     run::<u8>();


### PR DESCRIPTION
This PR fixes warnings raised by clippy, note that I had to modify the `regression_07` test which did not use the type parameter `T`.